### PR TITLE
[refactor]: 优化了后端管理界面

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -81,10 +81,10 @@ class Printer(models.Model):
 
 class Category(models.Model):
   place = models.ForeignKey(Place, on_delete=models.CASCADE, related_name="categories")
-  name = models.TextField(max_length=500)
-  name_en = models.TextField(max_length=500,blank=True, null=True)
-  name_es = models.TextField(max_length=500,blank=True, null=True)
-  name_pt = models.TextField(max_length=500,blank=True, null=True)
+  name = models.TextField(max_length=500) # Default/Chinese name
+  name_en = models.TextField(max_length=500,blank=True, null=True) # English name
+  # name_es = models.TextField(max_length=500,blank=True, null=True) # Spanish name - REMOVED
+  name_pt = models.TextField(max_length=500,blank=True, null=True) # Portuguese name
   created_at = models.DateTimeField(default=timezone.now)
   orders_display = models.IntegerField(blank=True,null=True)
   def __str__(self):
@@ -108,14 +108,14 @@ class MenuItem(models.Model):
   price = models.FloatField(default=0)
   image = models.ImageField(upload_to='menu_item_images/', blank=True, null=True)
   is_available = models.BooleanField(default=True)
-  name_en = models.TextField(max_length=500,blank=True, null=True)
-  name_es = models.TextField(max_length=500,blank=True, null=True)
-  name_pt = models.TextField(max_length=500,blank=True, null=True)
+  name_en = models.TextField(max_length=500,blank=True, null=True) # English name
+  # name_es = models.TextField(max_length=500,blank=True, null=True) # Spanish name - REMOVED
+  name_pt = models.TextField(max_length=500,blank=True, null=True) # Portuguese name
   name_to_print = models.TextField(max_length=500,blank=True, null=True)
-  description = models.TextField(blank=True, null=True)
-  description_en = models.TextField(blank=True, null=True)
-  description_es = models.TextField(blank=True, null=True)
-  description_pt = models.TextField(blank=True, null=True)
+  description = models.TextField(blank=True, null=True) # Default/Chinese description
+  description_en = models.TextField(blank=True, null=True) # English description
+  # description_es = models.TextField(blank=True, null=True) # Spanish description - REMOVED
+  description_pt = models.TextField(blank=True, null=True) # Portuguese description
   created_at = models.DateTimeField(default=timezone.now)
   ordering_timing = models.TextField(max_length=500, default=lunch_and_dinner,choices=ORDERING_TIMING)
   lunch_time_start = models.IntegerField(null=True, blank=True)

--- a/core/serializers.py
+++ b/core/serializers.py
@@ -18,7 +18,7 @@ class CategorySerializer(serializers.ModelSerializer):
       'place',
       'name_en',
       'name_pt',
-      'name_es',
+      # 'name_es', # Removed Spanish field
       'orders_display'
     )
 

--- a/core/utils.py
+++ b/core/utils.py
@@ -174,15 +174,22 @@ def handle_lunch_dinner_time(place,data):
 def translate_menu_name_description(data):
 
     translator = Translator()
-    name_en = translator.translate(data['name'], dest='en').text
-    name_pt = translator.translate(data['name'], dest='pt').text
-    name_es = translator.translate(data['name'], dest='es').text
+    name_en = ""
+    name_pt = ""
+    description_en = ""
+    description_pt = ""
 
-    description_en = translator.translate(data['description'], dest='en').text
-    description_es = translator.translate(data['description'], dest='es').text
-    description_pt = translator.translate(data['description'], dest='pt').text
+    # Ensure 'name' and 'description' exist in data to avoid KeyError
+    # and only translate if they are not empty strings.
+    if data.get('name'):
+        name_en = translator.translate(data['name'], dest='en').text
+        name_pt = translator.translate(data['name'], dest='pt').text
+    
+    if data.get('description'):
+        description_en = translator.translate(data['description'], dest='en').text
+        description_pt = translator.translate(data['description'], dest='pt').text
 
-    return name_en,name_pt,name_es,description_en,description_es,description_pt
+    return name_en, name_pt, description_en, description_pt
 
 
 def grouped_details(data,printers):

--- a/core/views.py
+++ b/core/views.py
@@ -169,13 +169,13 @@ def create_category_intent(request):
         translator = Translator()
         name_en = translator.translate(data['name'], src='zh-CN', dest='en').text
         name_pt = translator.translate(data['name'],src='zh-CN', dest='pt').text
-        name_es = translator.translate(data['name'], src='zh-CN',dest='es').text
+        # name_es = translator.translate(data['name'], src='zh-CN',dest='es').text # Removed Spanish translation
         category = models.Category.objects.create(
             place_id=data['place'],
             name=data['name'],
             name_en=name_en,
-            name_pt=name_pt,
-            name_es=name_es
+            name_pt=name_pt
+            # name_es=name_es # Removed Spanish field
         )
 
         return JsonResponse({
@@ -216,10 +216,29 @@ def create_menu_items_intent(request):
             name_to_print = form_data.get("name_to_print", "")
             if not name_to_print and form_data.get('name'): # Default print name to name if empty
                  name_to_print = form_data.get('name')
-
-            ordering_timing = str(form_data.get("ordering_timing", "lunch_and_dinner"))
             
-            name_en,name_pt,name_es,description_en,description_es,description_pt = translate_menu_name_description(form_data)
+            # Assuming translate_menu_name_description can take a dict-like object (request.POST)
+            # or modify to pass individual fields
+            # Adjust translate_menu_name_description to not return/process Spanish if it's a custom util function
+            # For now, assuming it might return more than needed, and we'll pick what we need.
+            # Or, if it's a direct call to googletrans multiple times, remove the 'es' calls.
+            # Let's assume translate_menu_name_description is a black box for now and we just don't use _es results.
+            # Ideally, translate_menu_name_description itself should be modified.
+            # For a direct fix here, if it returns a tuple:
+            # name_en, name_pt, _, description_en, _, description_pt = translate_menu_name_description(form_data)
+            # This is risky if the function signature changes.
+            # A safer modification is to adjust what's passed to it or how it's called if it's a series of direct translations.
+            # Given the function name, it likely does multiple translations.
+            # We will assume for now that the function `translate_menu_name_description` will be updated separately
+            # or that we can simply ignore the Spanish parts it might return.
+            # For the purpose of this diff, I will remove _es from being assigned and used.
+            
+            # This implies translate_menu_name_description might need to change its return signature
+            # or the way it's called. For now, let's assume it's modified to not return Spanish.
+            # If translate_menu_name_description is a series of direct calls, those for 'es' would be removed.
+            # If it's a utility, that utility needs to be updated.
+            
+            name_en, name_pt, description_en, description_pt = translate_menu_name_description(form_data)
 
             menu_item_data = {
                 'place_id': place_id,
@@ -230,10 +249,10 @@ def create_menu_items_intent(request):
                 'is_available': form_data.get('is_available', 'true').lower() == 'true',
                 'name_en': name_en,
                 'name_pt': name_pt,
-                'name_es': name_es,
+                # 'name_es' field is removed from model, so no need to include it here
                 'name_to_print': name_to_print,
                 'description_en': description_en,
-                'description_es': description_es,
+                # 'description_es' field is removed from model
                 'description_pt': description_pt,
                 'ordering_timing': ordering_timing,
                 'lunch_time_start': lunch_time_start,     


### PR DESCRIPTION
本次更新主要围绕店铺管理后台的功能增强、UI优化以及多语言支持的完善，具体包括：

**一、核心功能增强与修复：**

1.  **菜单项创建流程修复 (后台)**：
    *   修复了 `new_backend/core/views.py` 中的 `create_menu_items_intent` 视图，使其能正确处理从前端发送的 `FormData` (包括图片文件)，解决了之前创建带图片的菜品时可能失败或提示信息不准确的问题。
    *   前端 `new_frontend/src/containers/MenuItemForm.js` 相应调整了API调用成功后的提示逻辑。

2.  **店铺桌子数量管理**:
    *   在 `new_frontend/src/pages/Place.js`（店铺管理主界面）新增了“店铺设置”入口按钮。
    *   点击该按钮会弹出模态框，内含 `new_frontend/src/components/EditPlace.js` 表单，用户可在此表单中修改包括“桌子数量”在内的店铺信息。
    *   `EditPlace.js` 组件增加了 `onDone` 回调，确保更新成功后能关闭模态框并刷新父页面的店铺数据。
    *   后端 `Place` 模型已有的 `save()` 方法会自动根据 `number_of_tables` 的变化增删 `Table` 记录。

3.  **点餐链接/二维码生成页面优化 (`new_frontend/src/pages/SelectTable.js`)**:
    *   UI从原先的下拉选择框改为更直观的卡片式布局，每个桌号一个卡片。
    *   页面现在会从后端动态获取当前店铺的实际桌号列表进行展示。
    *   点击桌号卡片可直接在新标签页打开该桌号对应的顾客点餐界面。
    *   页面标题已进行国际化处理。

4.  **“今日订单”页面增强 (`new_frontend/src/pages/Orders.js`)**:
    *   在每个桌号按钮旁增加了快捷链接图标，点击可直接打开对应桌号的顾客点餐界面。
    *   根据用户反馈，暂时注释掉了原有的“选择人数”下拉框及其相关逻辑，以简化界面和解决UI拥挤问题。后续可根据需要恢复。
    *   调整了桌号按钮、链接按钮之间的间距，使其布局更美观。

**二、多语言支持与UI优化 (主要针对 `new_frontend/src/pages/MenuSettings.js`)**

1.  **语言支持范围调整**:
    *   系统现在主要支持中文（默认）、英文 (en) 和葡萄牙文 (pt)，移除了对西班牙文 (es) 的支持。
    *   后端模型 (`models.py`)、序列化器 (`serializers.py`) 及自动翻译逻辑 (`utils.py`, `views.py`) 均已更新，不再处理西班牙语相关字段和翻译。
    *   前端编辑表单（如 `EditMenuItemForm.js`, `MenuSettings.js` 中的分类编辑）也移除了西班牙语输入字段。

2.  **菜单设置页面多语言显示与编辑**:
    *   **分类编辑**: “编辑分类”模态框现在允许用户查看和修改分类的中文、英文和葡萄牙文名称。
    *   **全局语言切换**: 页面顶部新增了语言切换下拉菜单（带国旗图标），用户可切换整个“菜单设置”页面的预览语言。
    *   **动态内容翻译**:
        *   分类列表、菜单项列表中的名称和描述，以及右侧面板标题（如“XX分类的菜单项”）中的分类名，现在都会根据全局选择的语言动态显示对应翻译。
        *   修复了之前切换语言后部分静态文本和动态插值内容未正确翻译的问题。
    *   **UI优化**:
        *   语言切换下拉菜单的样式进行了优化，使其尺寸更合适，并增加了国旗图标。
        *   解决了因页面标题文本长度随语言切换变化而导致语言切换按钮位置“跳动”的布局问题。
        *   菜单项列表的显示更加丰富，增加了图片缩略图和描述预览。

3.  **国际化文本更新**:
    *   为新添加或修改的UI元素（如 `SelectTable.js` 标题、`MenuSettings.js` 中编辑分类的多语言标签等）更新了 `zh`, `en`, `pt` 的 `translation.json` 文件。

4.  **图片预览修复 (`new_frontend/src/containers/ImageDropzone.js`)**:
    *   改进了 `ImageDropzone` 组件处理已存图片URL的逻辑，确保在编辑带有图片的菜单项时能正确显示预览图。

**三、其他小调整与清理：**

*   在 `new_frontend/src/pages/Place.js` 中注释掉了“外卖订单”按钮，因目前不需要此功能。
*   代码中进行了一些小的清理和逻辑优化。

这些更改旨在提升应用的功能完整性、用户体验和多语言管理的便捷性。
